### PR TITLE
Sequentically run rebalancing after successful liquidations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1457,6 +1457,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46f93780a459b7d656ef7f071fe699c4d3d2cb201c4b24d085b6ddc505276e73"
+dependencies = [
+ "nix 0.30.1",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1875,6 +1885,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crossbeam",
+ "ctrlc",
  "dirs",
  "env_logger",
  "fixed",
@@ -1895,6 +1906,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sha2 0.10.9",
+ "signal-hook",
  "solana-account-decoder",
  "solana-cli-output",
  "solana-client",
@@ -3403,6 +3415,18 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset 0.9.1",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -5202,6 +5226,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5745,7 +5779,7 @@ dependencies = [
  "bincode",
  "crossbeam-channel",
  "log",
- "nix",
+ "nix 0.29.0",
  "rand 0.8.5",
  "serde",
  "serde_derive",
@@ -5785,7 +5819,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "nix",
+ "nix 0.29.0",
  "rand 0.8.5",
  "rayon",
  "serde",
@@ -6365,7 +6399,7 @@ dependencies = [
  "itertools 0.12.1",
  "libc",
  "log",
- "nix",
+ "nix 0.29.0",
  "pem",
  "percentage",
  "quinn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,8 @@ warp = "0.3.7"
 prometheus = "0.13.4"
 indexmap = "2.9"
 tiny_http = "0.12"
+signal-hook = "0.3.18"
+ctrlc = "3.4.7"
 
 [dependencies.marginfi]
 git = "https://github.com/mrgnlabs/marginfi-v2"

--- a/src/cache/mints.rs
+++ b/src/cache/mints.rs
@@ -25,8 +25,8 @@ impl MintsCache {
             .cloned()
     }
 
-    pub fn get_mints(&self) -> Vec<&Pubkey> {
-        self.mints.keys().collect()
+    pub fn get_mints(&self) -> Vec<Pubkey> {
+        self.mints.keys().cloned().collect()
     }
 
     pub fn get_tokens(&self) -> Vec<Pubkey> {

--- a/src/cache_loader.rs
+++ b/src/cache_loader.rs
@@ -55,13 +55,9 @@ impl CacheLoader {
         })
     }
 
-    pub fn load_cache(
-        &self,
-        cache: &mut Cache,
-        new_liquidator_account: &Option<Pubkey>,
-    ) -> anyhow::Result<()> {
+    pub fn load_cache(&self, cache: &mut Cache) -> anyhow::Result<()> {
         self.load_luts(cache)?;
-        self.load_marginfi_accounts(cache, new_liquidator_account)?;
+        self.load_marginfi_accounts(cache)?;
         self.load_banks(cache)?;
         self.load_mints(cache)?;
         self.load_oracles(cache)?;
@@ -98,20 +94,13 @@ impl CacheLoader {
         Ok(())
     }
 
-    fn load_marginfi_accounts(
-        &self,
-        cache: &mut Cache,
-        new_liquidator_account: &Option<Pubkey>,
-    ) -> anyhow::Result<()> {
+    fn load_marginfi_accounts(&self, cache: &mut Cache) -> anyhow::Result<()> {
         thread_info!("Loading marginfi accounts, this may take a few minutes, please be patient!");
         let start = std::time::Instant::now();
-        let mut marginfi_accounts_pubkeys = self.load_marginfi_account_addresses(
+        let marginfi_accounts_pubkeys = self.load_marginfi_account_addresses(
             &cache.marginfi_program_id,
             &cache.marginfi_group_address,
         )?;
-        if let Some(new_liquidator_account) = new_liquidator_account {
-            marginfi_accounts_pubkeys.push(*new_liquidator_account);
-        }
 
         thread_info!("Loading marginfi accounts...");
         let marginfi_accounts = batch_get_multiple_accounts(

--- a/src/cache_loader.rs
+++ b/src/cache_loader.rs
@@ -302,9 +302,9 @@ impl CacheLoader {
                 let mint = cache.mints.try_get_account(&mint_account)?;
                 let signer_pk = cache.signer_pk;
                 let ix = spl_associated_token_account::instruction::create_associated_token_account_idempotent(
-                    &signer_pk, 
-                    &signer_pk, 
-                    &mint_account, 
+                    &signer_pk,
+                    &signer_pk,
+                    &mint_account,
                     &mint.account.owner
                 );
                 instructions.push(ix);

--- a/src/cache_loader.rs
+++ b/src/cache_loader.rs
@@ -301,7 +301,12 @@ impl CacheLoader {
                 let mint_account = cache.mints.try_get_mint_for_token(token_address)?;
                 let mint = cache.mints.try_get_account(&mint_account)?;
                 let signer_pk = cache.signer_pk;
-                let ix = spl_associated_token_account::instruction::create_associated_token_account_idempotent(&signer_pk, &signer_pk, &mint_account, &mint.account.owner);
+                let ix = spl_associated_token_account::instruction::create_associated_token_account_idempotent(
+                    &signer_pk, 
+                    &signer_pk, 
+                    &mint_account, 
+                    &mint.account.owner
+                );
                 instructions.push(ix);
             }
 

--- a/src/cli/entrypoints.rs
+++ b/src/cli/entrypoints.rs
@@ -75,9 +75,9 @@ pub fn run_liquidator(
     let mints = cache.mints.get_mints();
     if !mints
         .iter()
-        .any(|&mint| mint == &config.rebalancer_config.swap_mint)
+        .any(|mint| mint == &config.rebalancer_config.swap_mint)
     {
-        config.rebalancer_config.swap_mint = *mints[0]; // TODO: come up with a smarter logic for choosing the preferred asset
+        config.rebalancer_config.swap_mint = mints[0]; // TODO: come up with a smarter logic for choosing the preferred asset
         thread_info!("Configured preferred asset not found in cache, using the first one from cache as preferred: {}", config.rebalancer_config.swap_mint);
     }
 

--- a/src/cli/entrypoints.rs
+++ b/src/cli/entrypoints.rs
@@ -7,7 +7,6 @@ use crate::{
     geyser_processor::GeyserProcessor,
     liquidator::Liquidator,
     metrics::{FAILED_LIQUIDATIONS, LIQUIDATION_ATTEMPTS},
-    rebalancer::Rebalancer,
     thread_error, thread_info,
     wrappers::liquidator_account::LiquidatorAccount,
 };
@@ -56,26 +55,6 @@ pub fn run_liquidator(
         config.general_config.solana_clock_refresh_interval,
     )?;
 
-    // TODO: refactor this fake cache. Currently it's only needed to construct the LiquidatorAccount object.
-    // After construction it's replaced with the actual cache.
-    // This way we ensure that the potentially created liquidator (MarginFi) account is picked up when the cache is loaded.
-    let dummy_unused_cache = Cache::new(
-        wallet_pubkey,
-        config.general_config.marginfi_program_id,
-        marginfi_group_id,
-        clock.clone(),
-        Arc::clone(&preferred_mints),
-    );
-
-    // If there is no liquidator account for this group, we'll create it.
-    let mut new_liquidator_account: Option<Pubkey> = None;
-    let mut liquidator_account = LiquidatorAccount::new(
-        &config.general_config,
-        marginfi_group_id,
-        Arc::new(dummy_unused_cache),
-        &mut new_liquidator_account,
-    )?;
-
     thread_info!("Loading Cache...");
     let mut cache = Cache::new(
         wallet_pubkey,
@@ -90,7 +69,7 @@ pub fn run_liquidator(
         config.general_config.rpc_url.clone(),
         config.general_config.clone().address_lookup_tables,
     )?;
-    cache_loader.load_cache(&mut cache, &new_liquidator_account)?;
+    cache_loader.load_cache(&mut cache)?;
 
     // Check if the preferred asset is in the cache. If not, make the first one the preferred asset.
     let mints = cache.mints.get_mints();
@@ -113,27 +92,22 @@ pub fn run_liquidator(
     // Liquidator/Rebalancer -> TransactionManager
     let (geyser_tx, geyser_rx) = crossbeam::channel::unbounded::<GeyserUpdate>();
     let run_liquidation = Arc::new(AtomicBool::new(false));
-    let run_rebalance = Arc::new(AtomicBool::new(false));
 
     let cache = Arc::new(cache);
-    liquidator_account.cache = Arc::clone(&cache);
-    let liquidator_account_clone = liquidator_account.clone()?;
+
+    let liquidator_account = Arc::new(LiquidatorAccount::new(
+        &config.general_config.clone(),
+        marginfi_group_id,
+        config.rebalancer_config.swap_mint,
+        cache.clone(),
+    )?);
+
     let mut liquidator = Liquidator::new(
-        config.general_config.clone(),
-        config.liquidator_config.clone(),
-        liquidator_account,
+        config.clone(),
+        liquidator_account.clone(),
         run_liquidation.clone(),
         stop_liquidator.clone(),
-        Arc::clone(&cache),
-    )?;
-
-    let mut rebalancer = Rebalancer::new(
-        config.general_config.clone(),
-        config.rebalancer_config.clone(),
-        liquidator_account_clone,
-        run_rebalance.clone(),
-        stop_liquidator.clone(),
-        Arc::clone(&cache),
+        cache.clone(),
     )?;
 
     let geyser_service = GeyserService::new(
@@ -148,7 +122,6 @@ pub fn run_liquidator(
     let geyser_processor = GeyserProcessor::new(
         geyser_rx.clone(),
         run_liquidation.clone(),
-        run_rebalance.clone(),
         stop_liquidator.clone(),
         cache,
     )?;
@@ -175,17 +148,6 @@ pub fn run_liquidator(
         if let Err(e) = geyser_service.start() {
             thread_error!("GeyserService failed! {:?}", e);
             panic!("Fatal error in GeyserService!");
-        }
-    });
-
-    if new_liquidator_account.is_some() {
-        rebalancer.fund_liquidator_account()?;
-    }
-
-    thread::spawn(move || {
-        if let Err(e) = rebalancer.start() {
-            thread_error!("Rebalancer failed! {:?}", e);
-            panic!("Fatal error in Rebalancer!");
         }
     });
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -105,8 +105,6 @@ impl Eva01Config {
             .parse()
             .expect("Invalid TOKEN_ACCOUNT_DUST_THRESHOLD number");
 
-        let preferred_mints: Vec<Pubkey> = parse_pubkey_list("PREFERRED_MINTS")?;
-
         let swap_mint = Pubkey::from_str(
             &std::env::var("SWAP_MINT").expect("SWAP_MINT environment variable is not set"),
         )
@@ -122,7 +120,6 @@ impl Eva01Config {
 
         let rebalancer_config = RebalancerCfg {
             token_account_dust_threshold: I80F48::from_num(token_account_dust_threshold),
-            preferred_mints,
             swap_mint,
             jup_swap_api_url,
             slippage_bps,
@@ -253,7 +250,6 @@ impl std::fmt::Display for LiquidatorCfg {
 #[derive(Debug, Default, Clone)]
 pub struct RebalancerCfg {
     pub token_account_dust_threshold: I80F48,
-    pub preferred_mints: Vec<Pubkey>,
     pub swap_mint: Pubkey,
     pub jup_swap_api_url: String,
     pub slippage_bps: u16,
@@ -266,12 +262,10 @@ impl std::fmt::Display for RebalancerCfg {
             "Rebalancer Config: \n\
                 - Token account dust threshold: {}\n\
                 - Swap mint: {}\n\
-                - Preferred mints: {:?}\n\
                 - Jup Swap Api URL: {}\n\
                 - Slippage bps: {}\n",
             self.token_account_dust_threshold,
             self.swap_mint,
-            self.preferred_mints,
             self.jup_swap_api_url,
             self.slippage_bps,
         )

--- a/src/geyser.rs
+++ b/src/geyser.rs
@@ -97,6 +97,7 @@ impl GeyserService {
         thread_info!("Staring GeyserService.");
 
         let tracked_accounts_vec: Vec<Pubkey> = self.tracked_accounts.keys().copied().collect();
+        let tls_config = ClientTlsConfig::new().with_native_roots();
 
         while !self.stop.load(Ordering::Relaxed) {
             thread_info!("Connecting to Geyser...");
@@ -107,7 +108,7 @@ impl GeyserService {
             let mut client = self.tokio_rt.block_on(
                 GeyserGrpcClient::build_from_shared(self.endpoint.clone())?
                     .x_token(self.x_token.clone())?
-                    .tls_config(ClientTlsConfig::new().with_native_roots())?
+                    .tls_config(tls_config.clone())?
                     .connect(),
             )?;
 

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -83,7 +83,7 @@ impl Liquidator {
         }
 
         // Initial rebalancing
-        if let Err(error) = self.rebalancer.run() {
+        if let Err(error) = self.rebalancer.run(true) {
             thread_error!("Initial rebalancing failed: {:?}", error);
         }
 
@@ -149,7 +149,7 @@ impl Liquidator {
                 thread_info!("The Liquidation process is complete.");
 
                 if LIQUIDATION_ATTEMPTS.get() > lq_attempts {
-                    if let Err(error) = self.rebalancer.run() {
+                    if let Err(error) = self.rebalancer.run(false) {
                         thread_error!("Rebalancing failed: {:?}", error);
                         ERROR_COUNT.inc();
                     }

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -148,7 +148,7 @@ impl Liquidator {
 
                 thread_info!("The Liquidation process is complete.");
 
-                if (LIQUIDATION_ATTEMPTS.get() - lq_attempts) > 0f64 {
+                if LIQUIDATION_ATTEMPTS.get() > lq_attempts {
                     if let Err(error) = self.rebalancer.run() {
                         thread_error!("Rebalancing failed: {:?}", error);
                         ERROR_COUNT.inc();

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -82,9 +82,7 @@ impl Liquidator {
         }
 
         // Initial rebalancing
-        if let Err(error) = self.rebalancer.run(true) {
-            thread_error!("Initial rebalancing failed: {:?}", error);
-        }
+        self.rebalancer.run(true)?;
 
         thread_info!("Staring the Liquidator loop.");
         while !self.stop_liquidator.load(Ordering::Relaxed) {

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -31,7 +31,6 @@ use std::{
 };
 use std::{sync::atomic::Ordering, thread};
 
-#[allow(dead_code)]
 pub struct Liquidator {
     liquidator_account: Arc<LiquidatorAccount>,
     rebalancer: Rebalancer,

--- a/src/marginfi_ixs.rs
+++ b/src/marginfi_ixs.rs
@@ -237,6 +237,7 @@ pub fn initialize_marginfi_account(
     marginfi_group: Pubkey,
     signer_keypair: &Keypair,
 ) -> anyhow::Result<Pubkey> {
+    //TODO: confirm that it should not be PDA
     let marginfi_account_key = Keypair::new();
 
     let ix = make_create_ix(

--- a/src/marginfi_ixs.rs
+++ b/src/marginfi_ixs.rs
@@ -237,7 +237,6 @@ pub fn initialize_marginfi_account(
     marginfi_group: Pubkey,
     signer_keypair: &Keypair,
 ) -> anyhow::Result<Pubkey> {
-    //TODO: confirm that it should not be PDA
     let marginfi_account_key = Keypair::new();
 
     let ix = make_create_ix(

--- a/src/rebalancer.rs
+++ b/src/rebalancer.rs
@@ -160,7 +160,7 @@ impl Rebalancer {
 
     fn needs_to_be_rebalanced(&mut self, lq_acc: &MarginfiAccountWrapper) -> Result<bool> {
         Ok(self.has_non_preferred_tokens()?
-            || self.has_non_preferred_assets(&lq_acc.lending_account)?
+            || self.has_non_preferred_deposits(&lq_acc.lending_account)?
             || lq_acc.has_liabs())
     }
 
@@ -469,7 +469,7 @@ impl Rebalancer {
         Ok(false)
     }
 
-    fn has_non_preferred_assets(&self, lq_account: &LendingAccount) -> Result<bool> {
+    fn has_non_preferred_deposits(&self, lq_account: &LendingAccount) -> Result<bool> {
         Ok(lq_account
             .balances
             .iter()

--- a/src/rebalancer.rs
+++ b/src/rebalancer.rs
@@ -235,7 +235,7 @@ impl Rebalancer {
         }
 
         let mut mints = ward!(self
-            .sell_non_preferred_assets()
+            .sell_non_preferred_deposits()
             .map_err(|e| thread_error!("Failed to sell non preferred assets! {}", e))
             .ok());
         thread_debug!("Sold assets for {:?} non-preferred mints.", mints.len());
@@ -265,7 +265,7 @@ impl Rebalancer {
         }
     }
 
-    fn sell_non_preferred_assets(&mut self) -> Result<Vec<Pubkey>> {
+    fn sell_non_preferred_deposits(&mut self) -> Result<Vec<Pubkey>> {
         let liquidator_account = self
             .cache
             .marginfi_accounts

--- a/src/rebalancer.rs
+++ b/src/rebalancer.rs
@@ -41,7 +41,6 @@ const MIN_LIQUIDATIONS_COUNT: u64 = 10;
 
 /// The rebalancer is responsible to keep the liquidator account
 /// "rebalanced" -> Document this better
-#[allow(dead_code)]
 pub struct Rebalancer {
     signer: Keypair,
     liquidator_account: Arc<LiquidatorAccount>,

--- a/src/rebalancer.rs
+++ b/src/rebalancer.rs
@@ -385,7 +385,7 @@ impl Rebalancer {
             self.get_amount(liab_usd_value, &self.swap_mint_bank, Some(PriceBias::Low))?;
 
         let withdraw_amount = if required_swap_token.is_positive() {
-            // The withdral_all flag is purposefully ignored here.
+            // The withdraw_all flag is purposefully ignored here.
             // It is possible that the amount of collateral could be temporarily less than the required swap token amount
             // due to the liquidated liabilities
             let (max_withdraw_amount, _) =

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -277,10 +277,10 @@ impl<'a, T: OracleWrapperTrait> BankAccountWithPriceFeedEva<'a, T> {
 
 pub fn calc_total_weighted_assets_liabs(
     cache: &Arc<Cache>,
-    account: &MarginfiAccountWrapper,
+    account: &LendingAccount,
     requirement_type: RequirementType,
 ) -> Result<(I80F48, I80F48)> {
-    let baws = BankAccountWithPriceFeedEva::<OracleWrapper>::load(&account.lending_account, cache)?;
+    let baws = BankAccountWithPriceFeedEva::<OracleWrapper>::load(account, cache)?;
     let emode_config = build_emode_config(&baws)?;
 
     let mut total_assets = I80F48::ZERO;
@@ -307,8 +307,11 @@ pub fn build_emode_config<T: OracleWrapperTrait + Clone>(
 }
 
 pub fn get_free_collateral(cache: &Arc<Cache>, account: &MarginfiAccountWrapper) -> Result<I80F48> {
-    let (assets, liabs) =
-        calc_total_weighted_assets_liabs(cache, account, RequirementType::Initial)?;
+    let (assets, liabs) = calc_total_weighted_assets_liabs(
+        cache,
+        &account.lending_account,
+        RequirementType::Initial,
+    )?;
     if assets > liabs {
         Ok(assets - liabs)
     } else {

--- a/src/wrappers/liquidator_account.rs
+++ b/src/wrappers/liquidator_account.rs
@@ -13,6 +13,7 @@ use crate::{
     wrappers::oracle::OracleWrapper,
 };
 use anyhow::{anyhow, Result};
+use marginfi::state::marginfi_account::BalanceSide;
 use solana_client::{rpc_client::RpcClient, rpc_config::RpcSendTransactionConfig};
 
 use crate::wrappers::oracle::OracleWrapperTrait;
@@ -69,6 +70,7 @@ pub struct LiquidatorAccount {
     pub signer: Keypair,
     program_id: Pubkey,
     group: Pubkey,
+    preferred_mint_bank: Pubkey,
     rpc_client: RpcClient,
     cu_limit_ix: Instruction,
     pub cache: Arc<Cache>,
@@ -78,8 +80,8 @@ impl LiquidatorAccount {
     pub fn new(
         config: &GeneralConfig,
         marginfi_group_id: Pubkey,
+        preferred_mint: Pubkey,
         cache: Arc<Cache>,
-        new_liquidator_account: &mut Option<Pubkey>,
     ) -> Result<Self> {
         let signer = Keypair::from_bytes(&config.wallet_keypair)?;
         let rpc_client = RpcClient::new(config.rpc_url.clone());
@@ -91,16 +93,13 @@ impl LiquidatorAccount {
             marginfi_group_id,
         )?;
         thread_info!(
-            "Found {} MarginFi accounts for the provided signer",
-            accounts.len()
+            "Found {} MarginFi accounts for the provided signer: {:?}",
+            accounts.len(),
+            accounts
         );
-        for account in accounts.iter() {
-            thread_info!("MarginFi account: {:?}", account);
-        }
 
         let liquidator_address = if accounts.is_empty() {
             thread_info!("No MarginFi account found for the provided signer. Creating it...");
-
             let liquidator_marginfi_account = initialize_marginfi_account(
                 &rpc_client,
                 config.marginfi_program_id,
@@ -108,20 +107,28 @@ impl LiquidatorAccount {
                 &signer,
             )?;
 
-            thread::sleep(Duration::from_secs(20));
-
-            *new_liquidator_account = Some(liquidator_marginfi_account);
+            while cache
+                .marginfi_accounts
+                .try_get_account(&liquidator_marginfi_account)
+                .is_err()
+            {
+                thread_info!("Waiting for the new account info to arrive...");
+                thread::sleep(Duration::from_secs(5));
+            }
 
             liquidator_marginfi_account
         } else {
             accounts[0]
         };
 
+        let preferred_mint_bank = cache.banks.try_get_account_for_mint(&preferred_mint)?;
+
         Ok(Self {
             liquidator_address,
             signer,
             program_id: config.marginfi_program_id,
             group: marginfi_group_id,
+            preferred_mint_bank,
             rpc_client,
             cu_limit_ix: ComputeBudgetInstruction::set_compute_unit_limit(
                 config.compute_unit_limit,
@@ -130,23 +137,27 @@ impl LiquidatorAccount {
         })
     }
 
-    pub fn clone(&self) -> Result<Self> {
-        let rpc_url = self.rpc_client.url();
-        let rpc_client = RpcClient::new(rpc_url.clone());
+    pub fn has_funds(&self) -> Result<bool> {
+        let account = self
+            .cache
+            .marginfi_accounts
+            .try_get_account(&self.liquidator_address)?;
 
-        Ok(Self {
-            liquidator_address: self.liquidator_address,
-            signer: Keypair::from_bytes(&self.signer.to_bytes())?,
-            program_id: self.program_id,
-            group: self.group,
-            rpc_client,
-            cu_limit_ix: self.cu_limit_ix.clone(),
-            cache: Arc::clone(&self.cache),
-        })
+        let preferred_mint_bank = self.cache.banks.try_get_bank(&self.preferred_mint_bank)?;
+
+        let validation_result =
+            account
+                .get_balance_for_bank(&preferred_mint_bank)
+                .map(|(balance, side)| match side {
+                    BalanceSide::Assets => balance > 0,
+                    _ => true,
+                });
+
+        Ok(validation_result.unwrap_or(false))
     }
 
     pub fn liquidate(
-        &mut self,
+        &self,
         liquidatee_account: &MarginfiAccountWrapper,
         asset_bank: &Pubkey,
         liab_bank: &Pubkey,

--- a/src/wrappers/liquidator_account.rs
+++ b/src/wrappers/liquidator_account.rs
@@ -424,10 +424,11 @@ impl LiquidatorAccount {
             );
 
         thread_debug!(
-            "Withdrawing {:?} unscaled Mint {} tokens from the Liquidator Account {:?}",
+            "Withdrawing {:?} unscaled tokens of the Mint {} from the Liquidator account {:?}, Bank {:?}, ",
             amount,
             mint,
-            token_account
+            token_account,
+            self.preferred_mint_bank
         );
 
         let res = self
@@ -442,11 +443,7 @@ impl LiquidatorAccount {
             )
             .map_err(|e| anyhow::anyhow!(e))?;
 
-        thread_debug!(
-            "Withdrawal result for Liquidator account {:?} (without preflight check): {:?} ",
-            marginfi_account,
-            res
-        );
+        thread_debug!("Withdrawal txn: {:?} ", res);
         Ok(())
     }
 
@@ -479,7 +476,12 @@ impl LiquidatorAccount {
                 recent_blockhash,
             );
 
-        thread_debug!("Repaying {:?}, token account {:?}", amount, token_account);
+        thread_debug!(
+            "Repaying {:?} unscaled tokens to the bank {}, token account {:?}",
+            amount,
+            bank.address,
+            token_account
+        );
 
         let res = self
             .rpc_client
@@ -492,7 +494,7 @@ impl LiquidatorAccount {
                 },
             );
         thread_debug!(
-            "Repaying result for account {:?} (without preflight check): {:?} ",
+            "The repaying result for account {:?} (without preflight check): {:?} ",
             marginfi_account,
             res
         );

--- a/src/wrappers/marginfi_account.rs
+++ b/src/wrappers/marginfi_account.rs
@@ -42,7 +42,7 @@ impl MarginfiAccountWrapper {
             .collect::<Vec<_>>()
     }
 
-    pub fn get_deposits(&self, banks_to_exclude: &[Pubkey]) -> Vec<Pubkey> {
+    pub fn get_assets(&self, banks_to_exclude: &[Pubkey]) -> Vec<Pubkey> {
         self.lending_account
             .balances
             .iter()
@@ -297,7 +297,7 @@ mod tests {
             healthy.get_liabilities_shares(),
             vec![(I80F48::from_num(100), usdc_bank.address)]
         );
-        assert_eq!(healthy.get_deposits(&[]), vec![sol_bank.address]);
+        assert_eq!(healthy.get_assets(&[]), vec![sol_bank.address]);
         let (balance, side) = healthy.get_balance_for_bank(&sol_bank).unwrap();
         assert_eq!(balance, I80F48::from_num(100));
         match side {
@@ -328,7 +328,7 @@ mod tests {
             unhealthy.get_liabilities_shares(),
             vec![(I80F48::from_num(100), sol_bank.address)]
         );
-        assert_eq!(unhealthy.get_deposits(&[]), vec![usdc_bank.address]);
+        assert_eq!(unhealthy.get_assets(&[]), vec![usdc_bank.address]);
         let (balance, side) = unhealthy.get_balance_for_bank(&sol_bank).unwrap();
         assert_eq!(balance, I80F48::from_num(100));
         match side {


### PR DESCRIPTION
1. Made rebalancing sequential to the liquidation process. That simplified the whole liquidation -> rebalancing process.
2. Added shutdown hooks for graceful shutdown.
3. Improved the Liquidator account creation for new Arena groups.