### PR TITLE
Print the Banks and Oracles configurations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,3 +69,7 @@ serial_test = "3.2.0"
 [profile.release]
 opt-level = 3
 lto = true
+
+[features]
+print_oracles = []
+print_banks = []

--- a/src/cache/banks.rs
+++ b/src/cache/banks.rs
@@ -56,6 +56,24 @@ impl BanksCache {
     pub fn len(&self) -> usize {
         self.banks.len()
     }
+
+    //Handy for printing the most current banks configuration. Requires the `print_banks` feature to be enabled.
+    #[cfg(feature = "print_banks")]
+    pub fn print_banks_info(&self) {
+        println!("Group, Bank, State, Risk-Tier, Mint, Oracle_Type, Oracles");
+        for bank in self.banks.values() {
+            println!(
+                "{:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}",
+                bank.bank.group,
+                bank.address,
+                bank.bank.config.operational_state,
+                bank.bank.config.risk_tier,
+                bank.bank.mint,
+                bank.bank.config.oracle_setup,
+                find_oracle_keys(&bank.bank.config)
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/cache/oracles.rs
+++ b/src/cache/oracles.rs
@@ -88,6 +88,15 @@ impl OraclesCache {
             })?
             .len())
     }
+
+    //Handy for obtaining the most current oracles configuration. Requires the `print_oracles` feature to be enabled.
+    #[cfg(feature = "print_oracles")]
+    pub fn print_oracles_info(&self) {
+        println!("Address, Owner");
+        for (address, account) in self.accounts.read().unwrap().iter() {
+            println!("{}, {}", address, account.owner);
+        }
+    }
 }
 #[cfg(test)]
 mod tests {

--- a/src/cache_loader.rs
+++ b/src/cache_loader.rs
@@ -62,6 +62,17 @@ impl CacheLoader {
         self.load_mints(cache)?;
         self.load_oracles(cache)?;
         self.load_tokens(cache)?;
+
+        #[cfg(feature = "print_oracles")]
+        {
+            cache.oracles.print_oracles_info();
+        }
+
+        #[cfg(feature = "print_banks")]
+        {
+            cache.banks.print_banks_info();
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
The change is purely for troubleshooting purposes and not very helpful in production, that is why I wrapped it in the compilation feature flags, which I usually despise. :-)